### PR TITLE
Bump ProjectJsonMigration

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
@@ -5,7 +5,7 @@
     <WarningsAsErrors>true</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <Version>0.1.0-alpha-$(CommitCount)</Version>
+    <Version>1.1.0-alpha-$(CommitCount)</Version>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
ProjectJsonMigration is already published via CLI project. The old one has higher
version than the current on. Make it has higher version so policy will
choose the latest