### PR TITLE
Lock dependency version

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
@@ -14,7 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0-rc4-61325-08" />
-    <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
+    <PackageReference Include="NuGet.Packaging.Core.Types" Version="4.3.0-preview1-2500" />
+    <PackageReference Include="NuGet.ProjectModel" Version="4.3.0-preview1-2500" />
+    <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due due to https://github.com/NuGet/Home/issues/5139 which happened last week
There is a conflict between "auto"(come from cli.util package) version of NuGet.Packaging and latest version.

Explicit state the version number in migrate package