### PR TITLE
Update version tags to match PackageVersion.props

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -14,21 +14,21 @@
 
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <MicrosoftCodeAnalysisCSharpVersion>2.1.0</MicrosoftCodeAnalysisCSharpVersion>
-    <MicrosoftDotNetCliUtilsVersion>1.0.1</MicrosoftDotNetCliUtilsVersion>
-    <NuGetPackagingCoreVersion>4.3.0-rtm-4324</NuGetPackagingCoreVersion>
-    <NuGetProjectModelVersion>4.3.0-rtm-4324</NuGetProjectModelVersion>
-    <SystemCollectionsSpecializedVersion>4.3.0</SystemCollectionsSpecializedVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.1.0</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftDotNetCliUtilsPackageVersion>1.0.1</MicrosoftDotNetCliUtilsPackageVersion>
+    <NuGetPackagingCorePackageVersion>4.3.0-rtm-4324</NuGetPackagingCorePackageVersion>
+    <NuGetProjectModelPackageVersion>4.3.0-rtm-4324</NuGetProjectModelPackageVersion>
+    <SystemCollectionsSpecializedPackageVersion>4.3.0</SystemCollectionsSpecializedPackageVersion>
   </PropertyGroup>
 
   <!-- Test Dependencies -->
   <PropertyGroup>
-    <FluentAssertionsVersion>4.18.0</FluentAssertionsVersion>
-    <MicrosoftDotNetCliCommandLineVersion>0.1.0-alpha-142</MicrosoftDotNetCliCommandLineVersion>
-    <MicrosoftDotNetInternalAbstractionsVersion>1.0.500-preview2-1-003177</MicrosoftDotNetInternalAbstractionsVersion>
-    <MicrosoftDotNetPlatformAbstractionsVersion>1.0.3</MicrosoftDotNetPlatformAbstractionsVersion>
-    <SystemDiagnosticsProcessVersion>4.3.0</SystemDiagnosticsProcessVersion>
-    <SystemReflectionTypeExtensionsVersion>4.3.0</SystemReflectionTypeExtensionsVersion>
+    <FluentAssertionsPackageVersion>4.18.0</FluentAssertionsPackageVersion>
+    <MicrosoftDotNetCliCommandLinePackageVersion>0.1.0-alpha-142</MicrosoftDotNetCliCommandLinePackageVersion>
+    <MicrosoftDotNetInternalAbstractionsPackageVersion>1.0.500-preview2-1-003177</MicrosoftDotNetInternalAbstractionsPackageVersion>
+    <MicrosoftDotNetPlatformAbstractionsPackageVersion>1.0.3</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+    <SystemDiagnosticsProcessPackageVersion>4.3.0</SystemDiagnosticsProcessPackageVersion>
+    <SystemReflectionTypeExtensionsPackageVersion>4.3.0</SystemReflectionTypeExtensionsPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpVersion)" />
-    <PackageReference Include="NuGet.Packaging.Core" Version="$(NuGetPackagingCoreVersion)" />
-    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelVersion)" />
-    <PackageReference Include="System.Collections.Specialized" Version="$(SystemCollectionsSpecializedVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
+    <PackageReference Include="NuGet.Packaging.Core" Version="$(NuGetPackagingCorePackageVersion)" />
+    <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
+    <PackageReference Include="System.Collections.Specialized" Version="$(SystemCollectionsSpecializedPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.csproj
+++ b/src/Tests/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
-    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
+    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessPackageVersion)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(SystemReflectionTypeExtensionsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.DotNet.ProjectJsonMigration.Tests/Microsoft.DotNet.ProjectJsonMigration.Tests.csproj
+++ b/src/Tests/Microsoft.DotNet.ProjectJsonMigration.Tests/Microsoft.DotNet.ProjectJsonMigration.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
+++ b/src/Tests/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/src/Tests/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="$(MicrosoftDotNetCliCommandLineVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="$(MicrosoftDotNetInternalAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="$(MicrosoftDotNetCliCommandLinePackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="$(MicrosoftDotNetInternalAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XUnitVersion)" />
   </ItemGroup>
 

--- a/src/Tests/dotnet-migrate.Tests/dotnet-migrate.Tests.csproj
+++ b/src/Tests/dotnet-migrate.Tests/dotnet-migrate.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsVersion)" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsPackageVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="$(MicrosoftDotNetCliUtilsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The tags defining dependencies in Versions.props don't match the tag names produced in the PackageVersions.props file generated in source-build.  This prevents cli-migrate from picking up any dependency versions from previously source-built packages.