### PR TITLE
Avoid GenerateAssemblyInfo for sdk issues/2278

### DIFF
--- a/src/Tests/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
+++ b/src/Tests/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.Migration.Tests
             }
         }
 
-        [Fact(Skip = "flaky")]
+        [Fact]
         public void ItMigratesSolutionInTheFolderWhenWeRunMigrationInThatFolder()
         {
             var projectDirectory = TestAssets
@@ -241,7 +241,7 @@ namespace Microsoft.DotNet.Migration.Tests
 
             new DotnetCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .Execute($"build \"{solutionRelPath}\"")
+                .Execute($"build \"{solutionRelPath}\" -p:GenerateAssemblyInfo=false") // https://github.com/dotnet/sdk/issues/2278"
                 .Should()
                 .Pass();
         }
@@ -292,7 +292,7 @@ namespace Microsoft.DotNet.Migration.Tests
 
             new DotnetCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .Execute($"build \"{solutionRelPath}\"")
+                .Execute($"build \"{solutionRelPath}\" -p:GenerateAssemblyInfo=false") // https://github.com/dotnet/sdk/issues/2278
                 .Should()
                 .Pass();
 


### PR DESCRIPTION
Build test asset twice. It will fail, due to https://github.com/dotnet/sdk/issues/2278

It is likely msbuild scheduling contributed to the flakiness. Use GenerateAssemblyInfo=false will avoid the error completely.