### PR TITLE
Update branding for 3.0 preview

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,7 +9,7 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>1.3.1</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
   </PropertyGroup>
 
   <!-- Production Dependencies -->


### PR DESCRIPTION
'preview' should be used for 3.0 previews.