### PR TITLE
Onboard with async publishing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,14 +2,17 @@ trigger:
 - master
 
 variables:
-  teamName: Roslyn-Project-System
+  TeamName: Roslyn-Project-System
+  _DotNetArtifactsCategory: .NETCore
   ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     PB_PublishBlobFeedKey:
     PB_PublishBlobFeedUrl:
     _DotNetPublishToBlobFeed: false
+    _PublishUsingPipelines: false
   ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
     PB_PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
     _DotNetPublishToBlobFeed: true
+    _PublishUsingPipelines: true
 
 phases:
 - template: /eng/build.yml
@@ -76,6 +79,7 @@ phases:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/phases/publish-build-assets.yml
     parameters:
+      publishUsingPipelines: true
       dependsOn:
         - Windows_NT
       queue:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -27,6 +27,8 @@ phases:
         _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                   /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
                   /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                  /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                   /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                   /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                   /p:PB_PublishType=$(_PublishType)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2444

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dnceng.visualstudio.com/7ea9116e-9fac-403d-b258-b31fcf1bb293/_build/index?buildId=151961
Test release: https://dnceng.visualstudio.com/internal/_apps/hub/ms.vss-releaseManagement-web.cd-release-progress?_a=release-pipeline-progress&releaseId=4526